### PR TITLE
Disable gitignore in root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,0 @@
-# Ignore everything
-*
-
-# But not these files...
-!.gitignore
-!*/Assets/**/*.cs
-
-# ...even if they are in subdirectories
-!*/

--- a/.gitignore2.txt
+++ b/.gitignore2.txt
@@ -1,0 +1,9 @@
+# Ignore everything
+*
+
+# But not these files...
+!.gitignore
+!*/Assets/**/*.cs
+
+# ...even if they are in subdirectories
+!*/


### PR DESCRIPTION
Disabled gitignore in the root folder, now each project folder can use its own gitignore.

`.gitignore2.txt` is the gitignore that excludes everything but C# files.